### PR TITLE
Add a way to cancel Jobs when tests are running

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'omniauth'
 
 gem 'hive-messages', '~> 1.0', '>=1.0.7'
 gem 'mind_meld', '~> 0.1'
+gem 'res'
 gem 'test_rail-api', '~> 0.4', require: 'test_rail'
 
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
     overcommit (0.40.0)
       childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
+    ox (2.8.2)
     paperclip (4.3.7)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -196,6 +197,11 @@ GEM
     rake (11.3.0)
     representable (2.3.0)
       uber (~> 0.0.7)
+    res (1.2.20)
+      hive-messages (~> 1)
+      json (~> 1.8)
+      ox (~> 2.2)
+      test_rail-api (~> 0.4)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
     roar (1.0.4)
@@ -320,6 +326,7 @@ DEPENDENCIES
   pry-byebug
   rails (~> 4.1.6)
   rake (< 12.0)
+  res
   roar-rails
   rspec-rails (= 2.14.2)
   sass-rails (~> 4.0.0)
@@ -338,4 +345,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -92,10 +92,11 @@ class Job < ActiveRecord::Base
   end
 
   def can_cancel?
-    %w[queued reserved].include?(status)
+    %w[queued reserved running].include?(status)
   end
 
-  # TODO: replace this with a more elegant and non tests or test_rail specific implementation e.g: something that can deal with cuke tags, etc, also
+  # TODO: replace this with a more elegant and non tests or test_rail specific
+  # implementation e.g: something that can deal with cuke tags, etc, also
   # will leave until further requirements and design is understood
   def tests
     execution_variables['tests']
@@ -107,7 +108,8 @@ class Job < ActiveRecord::Base
 
   private
 
-  # TODO: replace this with a more elegant and non tests or test_rail specific implementation e.g: something that can deal with cuke tags, etc, also
+  # TODO: replace this with a more elegant and non tests or test_rail specific
+  # implementation e.g: something that can deal with cuke tags, etc, also
   # will leave until further requirements and design is understood
   def run_id
     job_group.execution_variables['run_id']

--- a/app/views/batches/show.html.erb
+++ b/app/views/batches/show.html.erb
@@ -92,7 +92,7 @@
             <%= content_tag_for(:tr, jobs, class: 'active') do |job| %>
                 <td>
                   <% if job.original_job %>
-                      <%= link_to "<span class='glyphicon glyphicon-chevron-up'></span> (retry)".html_safe, job_path(job) %>
+                      <%= link_to "<span class='glyphicon glyphicon-chevron-up'></span> ##{job.id}".html_safe, job_path(job) %>
                   <% else %>
                       <%= link_to "##{job.id}", job_path(job) %>
                   <% end %>

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -58,8 +58,8 @@ describe Job do
     describe '#can_cancel?' do
       let(:job) { Fabricate(:job, state: job_state, result: job_result) }
 
-      context 'job is in a running state' do
-        let(:job_state) { 'running' }
+      context 'job is in a complete state' do
+        let(:job_state) { 'complete' }
         let(:job_result) { nil }
 
         it 'can NOT be cancelled' do
@@ -168,7 +168,13 @@ describe Job do
       let(:errored_count) { 3 }
       let(:original_retry_count) { 4 }
 
-      let(:job) { Fabricate(:job, passed_count: passed_count, failed_count: failed_count, errored_count: errored_count, retry_count: original_retry_count) }
+      let(:job) do
+        Fabricate(:job,
+                  passed_count: passed_count,
+                  failed_count: failed_count,
+                  errored_count: errored_count,
+                  retry_count: original_retry_count)
+      end
 
       context 'job can NOT be retried' do
         let(:can_retry) { false }


### PR DESCRIPTION
Why:

* The cancel button was only avalible when the job was queued or
reserved

This change addresses the need by:

* Display cancel button while the tests are running
* Add the Res gem